### PR TITLE
chore: upgrade TypeScript to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,65 +1,65 @@
 {
-	"name": "@rsbuild/plugin-css-minimizer",
-	"version": "1.1.1",
-	"repository": "https://github.com/rstackjs/rsbuild-plugin-css-minimizer",
-	"license": "MIT",
-	"type": "module",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
-		}
-	},
-	"main": "./dist/index.js",
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "rslib",
-		"dev": "rslib -w",
-		"lint": "biome check .",
-		"lint:write": "biome check . --write",
-		"prepare": "simple-git-hooks && npm run build",
-		"test": "playwright test",
-		"bump": "npx bumpp"
-	},
-	"simple-git-hooks": {
-		"pre-commit": "npx nano-staged"
-	},
-	"nano-staged": {
-		"*.{js,jsx,ts,tsx,mjs,cjs}": [
-			"biome check --write --no-errors-on-unmatched"
-		]
-	},
-	"dependencies": {
-		"css-minimizer-webpack-plugin": "7.0.4",
-		"reduce-configs": "^1.1.1"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
-		"@playwright/test": "^1.58.2",
-		"@rsbuild/core": "1.7.3",
-		"@rslib/core": "^0.20.0",
-		"@types/node": "^24.12.0",
-		"nano-staged": "^0.9.0",
-		"playwright": "^1.58.2",
-		"simple-git-hooks": "^2.13.1",
-		"typescript": "^5.9.3"
-	},
-	"peerDependencies": {
-		"@rsbuild/core": "^1.0.0 || ^2.0.0-0"
-	},
-	"peerDependenciesMeta": {
-		"@rsbuild/core": {
-			"optional": true
-		}
-	},
-	"packageManager": "pnpm@10.32.1",
-	"publishConfig": {
-		"access": "public",
-		"registry": "https://registry.npmjs.org/"
-	}
+  "name": "@rsbuild/plugin-css-minimizer",
+  "version": "1.1.1",
+  "repository": "https://github.com/rstackjs/rsbuild-plugin-css-minimizer",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib",
+    "dev": "rslib -w",
+    "lint": "biome check .",
+    "lint:write": "biome check . --write",
+    "prepare": "simple-git-hooks && npm run build",
+    "test": "playwright test",
+    "bump": "npx bumpp"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx nano-staged"
+  },
+  "nano-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
+      "biome check --write --no-errors-on-unmatched"
+    ]
+  },
+  "dependencies": {
+    "css-minimizer-webpack-plugin": "7.0.4",
+    "reduce-configs": "^1.1.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@playwright/test": "^1.58.2",
+    "@rsbuild/core": "1.7.3",
+    "@rslib/core": "^0.20.0",
+    "@types/node": "^24.12.0",
+    "nano-staged": "^0.9.0",
+    "playwright": "^1.58.2",
+    "simple-git-hooks": "^2.13.1",
+    "typescript": "6.0.2"
+  },
+  "peerDependencies": {
+    "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "@rsbuild/core": {
+      "optional": true
+    }
+  },
+  "packageManager": "pnpm@10.32.1",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 1.7.3
       '@rslib/core':
         specifier: ^0.20.0
-        version: 0.20.0(core-js@3.47.0)(typescript@5.9.3)
+        version: 0.20.0(core-js@3.47.0)(typescript@6.0.2)
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
@@ -40,8 +40,8 @@ importers:
         specifier: ^2.13.1
         version: 2.13.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: 6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -1106,8 +1106,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1330,12 +1330,12 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.20.0(core-js@3.47.0)(typescript@5.9.3)':
+  '@rslib/core@0.20.0(core-js@3.47.0)(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 2.0.0-beta.8(core-js@3.47.0)
-      rsbuild-plugin-dts: 0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
@@ -2055,12 +2055,12 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  rsbuild-plugin-dts@0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@5.9.3):
+  rsbuild-plugin-dts@0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.0-beta.8(core-js@3.47.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   safe-buffer@5.2.1: {}
 
@@ -2138,7 +2138,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.16.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,15 @@
 {
-	"compilerOptions": {
-		"outDir": "./dist",
-		"baseUrl": "./",
-		"target": "ES2020",
-		"lib": ["DOM", "ESNext"],
-		"module": "Node16",
-		"strict": true,
-		"declaration": true,
-		"isolatedModules": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"resolveJsonModule": true,
-		"moduleResolution": "Node16"
-	},
-	"include": ["src"]
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2023",
+    "types": ["node"],
+    "lib": ["DOM", "ESNext"],
+    "declaration": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Upgrade TypeScript to 6.0.2.
- Replace the root `tsconfig.json` with the shared NodeNext configuration.
- Validate the change with `pnpm build` and `pnpm test`.

## Related Links

- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2